### PR TITLE
Remove wrong discovery URL

### DIFF
--- a/jenkins-editor-feature/feature.xml
+++ b/jenkins-editor-feature/feature.xml
@@ -230,7 +230,6 @@ and limitations under the License.
 
    <url>
       <update label="Jenkins Editor update site" url="https://dl.bintray.com/de-jcup/jenkinseditor"/>
-      <discovery label="Jenkins Editor Wiki (github)" url="https://github.com/de-jcup/eclipse-jenkins-editor/wiki"/>
    </url>
 
    <plugin


### PR DESCRIPTION
Discovery URLs are meant to point to remote update sites, not to arbitrary websites. Currently the wiki URL is added to the P2 update managers known update sites and P2 tries to get update site content from there, whenever it looks for updates.
See https://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2Fproduct_def_feature.htm for details.